### PR TITLE
Bumped version of ctags

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "q": "1.x.x",
         "lodash": "3.x.x || 2.4.x",
-        "ctags": "0.11.0",
+        "ctags": "2.0.0",
         "stringify": "3.1.0"
     },
     "browserify": {


### PR DESCRIPTION
Codebox doesn't currently build from a fresh pull due to ctags (or it's dependencies) being out of date.

This PR bumps the ctags version which allows the source to build successfully.
