### PR TITLE
Update ctags version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "q": "1.x.x",
         "lodash": "3.x.x || 2.4.x",
-        "ctags": "0.11.0",
+        "ctags": "2.1.0",
         "stringify": "3.1.0"
     },
     "browserify": {


### PR DESCRIPTION
Bump ctags version. Codebox refused to start up for me on recent Arch Linux if I did not bump ctag version in package.json. Unsure about minimum required version as I just used the latest one from npm.
